### PR TITLE
Fix json "omit empty" caveat

### DIFF
--- a/history.go
+++ b/history.go
@@ -41,7 +41,7 @@ type HistoryGetParams struct {
 	// Possible values: 0 - numeric float, 1 - character, 2 - log,
 	// 3 - numeric signed, 4, text
 	// Default: 3
-	History int `json:"history,omitempty"`
+	History int `json:"history" default:"3"`
 
 	// HistoryIDs filters search results to histories with the given History ID's.
 	HistoryIDs []string `json:"historyids,omitempty"`


### PR DESCRIPTION
When using "omitempty" inside struct definition, and the value is "0" (zero), there are some caveats:
https://stackoverflow.com/questions/38486564/unmarshal-marshal-json-with-int-set-to-0-does-not-seem-to-work