### PR TITLE
Added support for host interfaces and more metadata on hosts

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -1,0 +1,20 @@
+package zabbix
+
+import (
+	"errors"
+	"fmt"
+)
+
+type ZBXBoolean bool
+
+func (bit *ZBXBoolean) UnmarshalJSON(data []byte) error {
+	asString := string(data)
+	if asString == "1" || asString == "true" {
+		*bit = true
+	} else if asString == "0" || asString == "false" {
+		*bit = false
+	} else {
+		return errors.New(fmt.Sprintf("Boolean unmarshal error: invalid input %s", asString))
+	}
+	return nil
+}

--- a/host.go
+++ b/host.go
@@ -6,6 +6,39 @@ const (
 
 	// HostSourceDiscovery indicates that a Host was created by Host discovery.
 	HostSourceDiscovery = 4
+
+	// HostAvailabilityUnknown Unknown availability of host, never has come online
+	HostAvailabilityUnknown = 0
+
+	// HostAvailabilityAvailable Host is available
+	HostAvailabilityAvailable = 1
+
+	// HostAvailabilityUnavailable Host is NOT available
+	HostAvailabilityUnavailable = 2
+
+	// HostInventoryModeDisabled Host inventory in disabled
+	HostInventoryModeDisabled = -1
+
+	// HostInventoryModeManual Host inventory is managed manually
+	HostInventoryModeManual = 0
+
+	// HostInventoryModeAutomatic Host inventory is managed automatically
+	HostInventoryModeAutomatic = 1
+
+	// HostTLSConnectUnencryped connect unencrypted to or from host
+	HostTLSConnectUnencryped = 1
+
+	// HostTLSConnectPSK connect with PSK to or from host
+	HostTLSConnectPSK = 2
+
+	// HostTLSConnectCertificate connect with certificate to or from host
+	HostTLSConnectCertificate = 4
+
+	// HostStatusMonitored Host is monitored
+	HostStatusMonitored = 0
+
+	// HostStatusUnmonitored Host is not monitored
+	HostStatusUnmonitored = 1
 )
 
 // Host represents a Zabbix Host returned from the Zabbix API.
@@ -35,6 +68,34 @@ type Host struct {
 	MaintenanceID     string `json:"maintenanceid"`
 	MaintenanceType   string `json:"maintenance_type"`
 	MaintenanceFrom   string `json:"maintenance_from"`
+
+	// Status of the host
+	Status int `json:"status,string"`
+
+	// Availbility of host
+	// *NOTE*: this field was removed in Zabbix 5.4
+	// See: https://support.zabbix.com/browse/ZBXNEXT-6311
+	Available int `json:"available,string,omitempty"`
+
+	// Description of host
+	Description string `json:"description"`
+
+	// Inventory mode
+	InventoryMode int `json:"inventory_mode"`
+
+	// HostID of the proxy managing this host
+	ProxyHostID string `json:"proxy_hostid"`
+
+	// How should we connect to host
+	TLSConnect int `json:"tls_connect,string"`
+
+	// What type of connections we accept from host
+	TLSAccept int `json:"tls_accept,string"`
+
+	TLSIssuer      string `json:"tls_issuer"`
+	TLSSubject     string `json:"tls_subject"`
+	TLSPSKIdentity string `json:"tls_psk_identity"`
+	TLSPSK         string `json:"tls_psk"`
 }
 
 // HostGetParams represent the parameters for a `host.get` API call.

--- a/host_interface.go
+++ b/host_interface.go
@@ -1,0 +1,89 @@
+package zabbix
+
+const (
+	// HostInterfaceAvailabilityUnknown Unknown availability of host, never has come online
+	HostInterfaceAvailabilityUnknown = 0
+	// HostInterfaceAvailabilityAvailable Host is available
+	HostInterfaceAvailabilityAvailable = 1
+	// HostInterfaceAvailabilityUnavailable Host is NOT available
+	HostInterfaceAvailabilityUnavailable = 2
+
+	// HostInterfaceTypeAgent Host interface type agent
+	HostInterfaceTypeAgent = 1
+	// HostInterfaceTypeSNMP Host interface type SNMP
+	HostInterfaceTypeSNMP = 2
+	// HostInterfaceTypeIPMI Host interface type IPMI
+	HostInterfaceTypeIPMI = 3
+	// HostInterfaceTypeJMX Host interface type JMX
+	HostInterfaceTypeJMX = 4
+)
+
+// HostInterface  This class is designed to work with host interfaces.
+//
+// See https://www.zabbix.com/documentation/current/manual/api/reference/hostinterface/object#host_interface
+type HostInterface struct {
+	// (readonly) ID of the interface.
+	InterfaceID string `json:"interfaceid"`
+
+	// (readonly) Availability of host interface.
+	Available int `json:"available,string,omitempty"`
+
+	// DNS name used by the interface.
+	DNS string `json:"dns"`
+
+	// IP address used by the interface.
+	IP string `json:"ip"`
+
+	// (readonly) Error text if host interface is unavailable.
+	Error string `json:"error,omitempty"`
+
+	// (readonly) Time when host interface became unavailable.
+	ErrorsFrom *UnixTimestamp `json:"errors_from,string,omitempty"`
+
+	// ID of the host the interface belongs to.
+	HostID string `json:"hostid"`
+
+	// Whether the interface is used as default on the host. Only one interface of some type can be set as default on a host.
+	Main ZBXBoolean `json:"main,string"`
+
+	// Interface type.
+	Type int `json:"type,string"`
+
+	// Whether the connection should be made via IP.
+	UseIP ZBXBoolean `json:"useip,string"`
+}
+
+type HostInterfaceGetParams struct {
+	GetParameters
+
+	// Return only host interfaces used by the given hosts.
+	HostIDs []string `json:"hostids,omitempty"`
+
+	// Return only host interfaces with the given IDs.
+	InterfaceIDs []string `json:"interfaceids,omitempty"`
+
+	// Return only host interfaces used by the given items.
+	ItemIDs []string `json:"itemids,omitempty"`
+
+	// Return only host interfaces used by items in the given triggers.
+	TriggerIDs []string `json:"triggerids,omitempty"`
+}
+
+// GetHostInterfaces queries the Zabbix API for Hosts interfaces matching the given search
+// parameters.
+//
+// ErrEventNotFound is returned if the search result set is empty.
+// An error is returned if a transport, parsing or API error occurs.
+func (c *Session) GetHostInterfaces(params HostInterfaceGetParams) ([]HostInterface, error) {
+	hostInterfaces := make([]HostInterface, 0)
+	err := c.Get("hostinterface.get", params, &hostInterfaces)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(hostInterfaces) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return hostInterfaces, nil
+}

--- a/time.go
+++ b/time.go
@@ -1,0 +1,33 @@
+package zabbix
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+type UnixTimestamp struct {
+	*time.Time
+}
+
+func (t UnixTimestamp) MarshalJSON() ([]byte, error) {
+	stamp := fmt.Sprintf("\"%s\"", t.Unix())
+	return []byte(stamp), nil
+}
+
+func (t *UnixTimestamp) UnmarshalJSON(data []byte) (err error) {
+	var unixString string
+	err = json.Unmarshal(data, &unixString)
+	if err != nil {
+		return
+	}
+
+	unix, err := strconv.ParseInt(unixString, 10, 64)
+
+	// Fractional seconds are handled implicitly by Parse.
+	tt := time.Unix(unix, 0)
+	*t = UnixTimestamp{&tt}
+
+	return
+}


### PR DESCRIPTION
I've updated my previous PR #19 with support for Zabbix 5.4. They [removed "availability" from the hosts object in Zabbix 5.4](https://www.zabbix.com/documentation/current/manual/api/changes_5.2_-_5.4), so you need to query all interfaces now to see if any interface is available (and therefor the host). For compatibility with Zabbix 5.0 LTS I'm keeping the field "Available" in the host object.